### PR TITLE
Cannot match orders from same user

### DIFF
--- a/ms_matching_engine/services/orderbook.ts
+++ b/ms_matching_engine/services/orderbook.ts
@@ -312,6 +312,8 @@ export default class OrderBook implements IOrderBook {
    * Check if a given order matches against a given order in the orderbook
    */
   private isMatch(order: OrderBookOrder, matchAgainst: OrderBookOrder) {
+    // if the user is the same, it's not a match
+    if (order.user_id === matchAgainst.user_id) return false;
     if (order.stock_id !== matchAgainst.stock_id) return false;
     return order.is_buy
       ? matchAgainst.price <= order.price

--- a/ms_matching_engine/services/orderbook.ts
+++ b/ms_matching_engine/services/orderbook.ts
@@ -312,7 +312,6 @@ export default class OrderBook implements IOrderBook {
    * Check if a given order matches against a given order in the orderbook
    */
   private isMatch(order: OrderBookOrder, matchAgainst: OrderBookOrder) {
-    // if the user is the same, it's not a match
     if (order.user_id === matchAgainst.user_id) return false;
     if (order.stock_id !== matchAgainst.stock_id) return false;
     return order.is_buy

--- a/ms_matching_engine/tests/fifoMatching.test.ts
+++ b/ms_matching_engine/tests/fifoMatching.test.ts
@@ -29,7 +29,7 @@ describe("OrderBook FIFO Priority Tests", () => {
 
     const marketOrder: OrderBookOrder = {
       stock_tx_id: "1",
-      user_id: "1",
+      user_id: "2",
       stock_id: "1",
       quantity: 15,
       price: 10,

--- a/ms_matching_engine/tests/limitOrderMatching.test.ts
+++ b/ms_matching_engine/tests/limitOrderMatching.test.ts
@@ -25,7 +25,7 @@ describe("OrderBook Limit Order Tests", () => {
       },
     ];
     const order: OrderBookOrder = {
-      user_id: "1",
+      user_id: "2",
       stock_tx_id: "1",
 
       is_buy: true,
@@ -63,7 +63,7 @@ describe("OrderBook Limit Order Tests", () => {
       },
     ];
     const order = {
-      user_id: "1",
+      user_id: "2",
       stock_tx_id: "1",
 
       is_buy: true,
@@ -97,7 +97,7 @@ describe("OrderBook Limit Order Tests", () => {
       },
     ];
     const order = {
-      user_id: "1",
+      user_id: "2",
       stock_tx_id: "1",
 
       is_buy: false,
@@ -130,7 +130,7 @@ describe("OrderBook Limit Order Tests", () => {
         executed: false,
       },
       {
-        user_id: "1",
+        user_id: "2",
         stock_tx_id: "1",
 
         stock_id: "1",
@@ -143,7 +143,7 @@ describe("OrderBook Limit Order Tests", () => {
       },
     ];
     const order = {
-      user_id: "1",
+      user_id: "3",
       stock_tx_id: "1",
 
       is_buy: true,
@@ -176,7 +176,7 @@ describe("OrderBook Limit Order Tests", () => {
         executed: false,
       },
       {
-        user_id: "1",
+        user_id: "2",
         stock_tx_id: "1",
 
         stock_id: "1",
@@ -189,7 +189,7 @@ describe("OrderBook Limit Order Tests", () => {
       },
     ];
     const order = {
-      user_id: "1",
+      user_id: "3",
       stock_tx_id: "1",
 
       is_buy: false,
@@ -223,7 +223,7 @@ describe("OrderBook Limit Order Tests", () => {
       },
       {
         stock_id: "1",
-        user_id: "1",
+        user_id: "2",
         stock_tx_id: "1",
 
         price: 15,
@@ -235,7 +235,7 @@ describe("OrderBook Limit Order Tests", () => {
       },
     ];
     const order = {
-      user_id: "1",
+      user_id: "3",
       stock_tx_id: "1",
 
       is_buy: false,
@@ -269,7 +269,7 @@ describe("OrderBook Limit Order Tests", () => {
       },
       {
         stock_id: "1",
-        user_id: "1",
+        user_id: "2",
         stock_tx_id: "1",
 
         price: 8,
@@ -281,7 +281,7 @@ describe("OrderBook Limit Order Tests", () => {
       },
     ];
     const order = {
-      user_id: "1",
+      user_id: "3",
       stock_tx_id: "1",
 
       is_buy: true,
@@ -315,7 +315,7 @@ describe("OrderBook Limit Order Tests", () => {
       },
       {
         stock_id: "1",
-        user_id: "1",
+        user_id: "2",
         stock_tx_id: "1",
 
         price: 20,
@@ -329,7 +329,7 @@ describe("OrderBook Limit Order Tests", () => {
     orderbook.buyOrders = [
       {
         stock_id: "1",
-        user_id: "1",
+        user_id: "3",
         stock_tx_id: "1",
 
         price: 20,
@@ -341,7 +341,7 @@ describe("OrderBook Limit Order Tests", () => {
       },
       {
         stock_id: "1",
-        user_id: "1",
+        user_id: "5",
         stock_tx_id: "1",
 
         price: 20,
@@ -353,7 +353,7 @@ describe("OrderBook Limit Order Tests", () => {
       },
     ];
     const sellOrder = {
-      user_id: "1",
+      user_id: "4",
       stock_tx_id: "1",
 
       is_buy: false,
@@ -365,7 +365,7 @@ describe("OrderBook Limit Order Tests", () => {
       executed: false,
     };
     const buyOrder = {
-      user_id: "1",
+      user_id: "6",
       stock_tx_id: "1",
 
       is_buy: true,
@@ -399,7 +399,7 @@ describe("OrderBook Limit Order Tests", () => {
         executed: false,
       },
       {
-        user_id: "1",
+        user_id: "2",
         stock_tx_id: "1",
 
         stock_id: "1",
@@ -414,7 +414,7 @@ describe("OrderBook Limit Order Tests", () => {
 
     orderbook.buyOrders = [
       {
-        user_id: "1",
+        user_id: "3",
         stock_tx_id: "1",
 
         stock_id: "1",
@@ -426,7 +426,7 @@ describe("OrderBook Limit Order Tests", () => {
         executed: false,
       },
       {
-        user_id: "1",
+        user_id: "4",
         stock_tx_id: "1",
 
         stock_id: "1",
@@ -440,7 +440,7 @@ describe("OrderBook Limit Order Tests", () => {
     ] as OrderBookOrder[];
 
     const sellOrder: OrderBookOrder = {
-      user_id: "1",
+      user_id: "5",
       stock_tx_id: "1",
 
       is_buy: false,
@@ -453,7 +453,7 @@ describe("OrderBook Limit Order Tests", () => {
     };
 
     const buyOrder: OrderBookOrder = {
-      user_id: "1",
+      user_id: "6",
       stock_tx_id: "1",
 
       is_buy: true,

--- a/ms_matching_engine/tests/marketOrderMatching.test.ts
+++ b/ms_matching_engine/tests/marketOrderMatching.test.ts
@@ -9,6 +9,74 @@ describe("OrderBook Market Order Tests", () => {
     orderbook = new OrderBook(StockTransaction);
   });
 
+  // Preconditions:
+
+  // User 1 has 500 quantity of Stock A
+
+  // User 2 has sufficient funds in their account.
+
+  // Steps to Reproduce:
+
+  it("executes with correct price", () => {
+    // This tests a scenario described by Freya where the incorrect order is matched.
+    // We have no knowledge wallet transactions or anything, we just check the correct
+    // message is sent to the execution service.
+
+    // User 1 sell limit order Stock A quantity 10 at price 150
+    const order1: OrderBookOrder = {
+      user_id: "1",
+      stock_tx_id: "1",
+      stock_id: "1",
+      quantity: 10,
+      is_buy: false,
+      order_type: OrderType.LIMIT,
+      timestamp: new Date(new Date().getTime() - 5000),
+      executed: false,
+      price: 150,
+    };
+
+    orderbook.matchOrder(order1);
+
+    // User 1 sell limit order Stock A quantity 10 at price 125
+    const order2: OrderBookOrder = {
+      user_id: "1",
+      stock_tx_id: "1",
+      stock_id: "1",
+      quantity: 10,
+      is_buy: false,
+      order_type: OrderType.LIMIT,
+      timestamp: new Date(),
+      executed: false,
+      price: 125,
+    };
+
+    orderbook.matchOrder(order2);
+
+    // User 2 buy market order Stock A quantity 5
+    const order3: OrderBookOrder = {
+      user_id: "2",
+      stock_tx_id: "1",
+      stock_id: "1",
+      quantity: 5,
+      is_buy: true,
+      order_type: OrderType.MARKET,
+      timestamp: new Date(),
+      executed: false,
+      price: 150,
+    };
+
+    // User 2 Stock transaction shows buy order complete at price 150 and wallet transaction of 750
+    // it should buy at the best available price
+    const [matched, remainingQuantity] = orderbook.matchOrder(order3);
+    console.log(matched);
+    expect(matched.length).toBe(1);
+    expect(matched[0].quantity).toBe(5);
+    expect(remainingQuantity).toBe(0);
+    expect(orderbook.buyOrders.length).toBe(0);
+    expect(orderbook.sellOrders.length).toBe(2);
+    expect(matched[0].matchPrice).toBe(125);
+  });
+
   it("execute a sell market order at the best available buy price", () => {
     const olderTimeStamp = new Date(new Date().getTime() - 1000);
     const newerTimeStamp = new Date();

--- a/ms_matching_engine/tests/marketOrderMatching.test.ts
+++ b/ms_matching_engine/tests/marketOrderMatching.test.ts
@@ -9,13 +9,38 @@ describe("OrderBook Market Order Tests", () => {
     orderbook = new OrderBook(StockTransaction);
   });
 
-  // Preconditions:
 
-  // User 1 has 500 quantity of Stock A
-
-  // User 2 has sufficient funds in their account.
-
-  // Steps to Reproduce:
+  it("does not match orders from the same user", () => {
+    // user 1 sell limit order of stock a quantity 100
+    const order1: OrderBookOrder = {
+      user_id: "1",
+      stock_tx_id: "1",
+      stock_id: "1",
+      quantity: 100,
+      is_buy: false,
+      order_type: OrderType.LIMIT,
+      timestamp: new Date(),
+      executed: false,
+      price: 10,
+    };
+    orderbook.matchOrder(order1);
+    // user 1 buy market order of stock a quantity 5
+    const order2: OrderBookOrder = {
+      user_id: "1",
+      stock_tx_id: "1",
+      stock_id: "1",
+      quantity: 5,
+      is_buy: true,
+      order_type: OrderType.MARKET,
+      timestamp: new Date(),
+      executed: false,
+      price: 10,
+    };
+    const [matched, remainingQuantity] = orderbook.matchOrder(order2);
+    expect(matched.length).toBe(0);
+    expect(remainingQuantity).toBe(5);
+    
+  });
 
   it("executes with correct price", () => {
     // This tests a scenario described by Freya where the incorrect order is matched.
@@ -94,7 +119,7 @@ describe("OrderBook Market Order Tests", () => {
         executed: false,
       },
       {
-        user_id: "1",
+        user_id: "2",
         stock_tx_id: "1",
 
         stock_id: "1",
@@ -107,7 +132,7 @@ describe("OrderBook Market Order Tests", () => {
       },
     ];
     const marketOrder: OrderBookOrder = {
-      user_id: "1",
+      user_id: "3",
       stock_tx_id: "1",
 
       stock_id: "1",
@@ -162,7 +187,7 @@ describe("OrderBook Market Order Tests", () => {
       },
     ];
     const marketOrder: OrderBookOrder = {
-      user_id: "1",
+      user_id: "2",
       stock_tx_id: "1",
 
       stock_id: "1",
@@ -195,7 +220,7 @@ describe("OrderBook Market Order Tests", () => {
         executed: false,
       },
       {
-        user_id: "1",
+        user_id: "2",
         stock_tx_id: "1",
 
         stock_id: "1",
@@ -208,7 +233,7 @@ describe("OrderBook Market Order Tests", () => {
       },
     ];
     const marketOrder: OrderBookOrder = {
-      user_id: "1",
+      user_id: "3",
       stock_tx_id: "1",
 
       stock_id: "1",


### PR DESCRIPTION
Problem
---
### Preconditions
1. User 1 has quantity 100 of stock A
2. User 1 has sufficient funds

### Steps to Reproduce:
1. User 1 sell market order of Stock A quantity 100
2. User 1 buy market order of Stock A quantity 5
3. User 1 shows both stock and wallet transactions for sell and buy orders.

Fix
---
1. update the isMatch() function to check for same user id.
2. update unit tests to account for this behaviour